### PR TITLE
get/fancy_descriptor_structure

### DIFF
--- a/lib/get.js
+++ b/lib/get.js
@@ -8,7 +8,7 @@ const get = async dataset => {
   const dpJsonResource = File.load({
     path: 'datapackage.json',
     name: 'datapackage.json',
-    data: _descriptor
+    data: JSON.stringify(_descriptor, null, 2)
   })
   resources.push(dpJsonResource)
   // Add the readme - if it exists


### PR DESCRIPTION
https://github.com/datahq/datahub-qa/issues/150

`datahub-client/get()` method returns a list of dataset packages and adding there descriptor file and a readme file.
Descriptor `data.js.File` is now contains a prettified JSON string instead of javascript object,
So saved file is prettyfied, too.